### PR TITLE
fix: make the reporting console ui consistent

### DIFF
--- a/src/reporting/reporters/post-pipeline/console/global-warnings.ts
+++ b/src/reporting/reporters/post-pipeline/console/global-warnings.ts
@@ -13,22 +13,20 @@ import { buildOutcomeStatsConsoleMessage } from "./util.js";
 
 export function reportGlobalWarnings(warnings: GlobalWarning): void {
   if (warnings.length > 0) {
-    warnings.forEach((warning) => {
-      consolePrinter.font
-        .standard(`${warning}`)
-        .prefix(
-          consolePrinter.font.error("global warning:").underline().message
-        )
-        .bold()
-        .printWithEmptyLine();
-    });
-
     consolePrinter.font
       .error(
         `✖ ${warnings.length} global ${pluralize("warning", warnings.length)}`
       )
       .bold()
       .printWithEmptyLine();
+
+    warnings.forEach((warning) => {
+      consolePrinter.font
+        .standard(warning)
+        .prefix(consolePrinter.font.error(">>").message)
+        .bold()
+        .printWithEmptyLine();
+    });
 
     return;
   }

--- a/src/reporting/reporters/post-pipeline/console/util.ts
+++ b/src/reporting/reporters/post-pipeline/console/util.ts
@@ -22,10 +22,13 @@ export function buildOutcomeStatsConsoleMessage(
   if (statsLength > 0) {
     const printWarnOrErr = printWarnOrError(warningsMode);
 
-    return printWarnOrErr(`${statsLength}`).prefix(printWarnOrErr("✖").message);
+    return printWarnOrErr(`${statsLength}`)
+      .prefix(printWarnOrErr("✖").message)
+      .bold();
   }
 
   return consolePrinter.font
     .success(`${statsLength}`)
-    .prefix(consolePrinter.font.success("✓").message);
+    .prefix(consolePrinter.font.success("✓").message)
+    .bold();
 }

--- a/src/reporting/reporters/post-pipeline/console/util.ts
+++ b/src/reporting/reporters/post-pipeline/console/util.ts
@@ -1,4 +1,6 @@
-// Import Internal Dependencies
+// Import Third-party Dependencies
+import { match } from "ts-pattern";
+
 import {
   ConsoleMessage,
   ConsoleOutput,
@@ -6,6 +8,14 @@ import {
 } from "../../../../../lib/console-printer/index.js";
 import { Nsci } from "../../../../configuration/index.js";
 import { Warnings } from "../../../../configuration/standard/nsci";
+
+export function getOutcomeEmoji(warningsMode: Warnings): string {
+  return match(warningsMode)
+    .with("error", () => "✖")
+    .with("off", () => "✓")
+    .with("warning", () => "⚠")
+    .otherwise(() => "⚠");
+}
 
 export function printWarnOrError(
   warningsMode: Warnings
@@ -20,10 +30,11 @@ export function buildOutcomeStatsConsoleMessage(
   warningsMode: Warnings
 ): ConsoleMessage {
   if (statsLength > 0) {
+    const outcomeEmoji = getOutcomeEmoji(warningsMode);
     const printWarnOrErr = printWarnOrError(warningsMode);
 
     return printWarnOrErr(`${statsLength}`)
-      .prefix(printWarnOrErr("✖").message)
+      .prefix(printWarnOrErr(outcomeEmoji).message)
       .bold();
   }
 

--- a/src/reporting/reporters/post-pipeline/console/vulnerabilities.ts
+++ b/src/reporting/reporters/post-pipeline/console/vulnerabilities.ts
@@ -48,8 +48,9 @@ export function reportDependencyVulns(
     consolePrinter.util
       .concatOutputs([
         consolePrinter.font.error(`✖ ${vulnsLength}`).bold().message,
-        consolePrinter.font.error(`${pluralize("vulnerability", vulnsLength)}`)
-          .message
+        consolePrinter.font
+          .error(`${pluralize("vulnerability", vulnsLength)}`)
+          .bold().message
       ])
       .printWithEmptyLine();
   } else {

--- a/src/reporting/reporters/post-pipeline/console/vulnerabilities.ts
+++ b/src/reporting/reporters/post-pipeline/console/vulnerabilities.ts
@@ -33,18 +33,6 @@ export function reportDependencyVulns(
 ): void {
   const vulnsLength = vulnerabilities.length;
   if (vulnsLength > 0) {
-    for (const vuln of vulnerabilities) {
-      const vulnRanges = vuln.vulnerableRanges.join(", ");
-      const vulnColored = getColorBySeverity(vuln.severity);
-      consolePrinter.util
-        .concatOutputs([
-          vulnColored.bold().underline().message,
-          consolePrinter.font.standard(`[${vuln.package}]`).bold().message,
-          consolePrinter.font.standard(vuln.title).italic().message,
-          consolePrinter.font.info(vulnRanges).bold().message
-        ])
-        .printWithEmptyLine();
-    }
     consolePrinter.util
       .concatOutputs([
         consolePrinter.font.error(`✖ ${vulnsLength}`).bold().message,
@@ -53,6 +41,19 @@ export function reportDependencyVulns(
           .bold().message
       ])
       .printWithEmptyLine();
+
+    for (const vuln of vulnerabilities) {
+      const vulnRanges = vuln.vulnerableRanges.join(", ");
+      const vulnColored = getColorBySeverity(vuln.severity);
+      consolePrinter.util
+        .concatOutputs([
+          vulnColored.bold().underline().message,
+          consolePrinter.font.standard(`(${vuln.package}):`).bold().message,
+          consolePrinter.font.standard(vuln.title).italic().message,
+          consolePrinter.font.info(vulnRanges).bold().message
+        ])
+        .printWithEmptyLine();
+    }
   } else {
     consolePrinter.font
       .success("✓ 0 vulnerabilities detected in the dependency tree")


### PR DESCRIPTION
Related to #8 

There were few edge cases where console reporting was not consistent. This PR is in charge of two things:

- Make sure emojis and colors (⚠/yellow, ✓/green, ✖/red) are consistent with the behavior of the interpretation (including configuration) phase.

- Make sure the display order is consistent for each reporting phase:
          1. First the outcome of the phase e.g: `⚠ 144 dependency warnings`
          2. Second the details of the phase e.g: `unsafe-regex strnum/strnum.js:2:17,2:94...`

This PR also deals with the reporting of the `.nodesecureignore` file which is now in the same format as the rest of the reporting process.
