### PR TITLE
refactor: use js-x-ray warnings values and type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
+        "@nodesecure/js-x-ray": "^5.0.1",
         "@nodesecure/rc": "^1.2.0",
         "@nodesecure/scanner": "^3.6.0",
         "@nodesecure/vuln": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
+    "@nodesecure/js-x-ray": "^5.0.1",
     "@nodesecure/rc": "^1.2.0",
     "@nodesecure/scanner": "^3.6.0",
     "@nodesecure/vuln": "^1.7.0",

--- a/src/analysis/interpretation/warnings.ts
+++ b/src/analysis/interpretation/warnings.ts
@@ -67,10 +67,10 @@ function retrieveAllWarningsWithSharedMode(
 }
 
 function groupWarningKindsByWarningMode(
-  warningsWithSpecificMode: Record<Nsci.WarningKind, Nsci.WarningMode>
+  warningsWithSpecificMode: Record<Nsci.WarningName, Nsci.WarningMode>
 ): {
-  allWarningsKindsWithErrorMode: Set<Nsci.WarningKind>;
-  allWarningsKindsWithWarningMode: Set<Nsci.WarningKind>;
+  allWarningsKindsWithErrorMode: Set<Nsci.WarningName>;
+  allWarningsKindsWithWarningMode: Set<Nsci.WarningName>;
 } {
   const warningKindsGroupedByWarningMode = Object.entries(
     warningsWithSpecificMode
@@ -78,7 +78,7 @@ function groupWarningKindsByWarningMode(
     (warningsGroupedByMode, [warningKind, warningValue]) => {
       warningsGroupedByMode[warningValue] = [
         ...warningsGroupedByMode[warningValue],
-        warningKind as Nsci.WarningKind
+        warningKind as Nsci.WarningName
       ];
 
       return warningsGroupedByMode;
@@ -87,7 +87,7 @@ function groupWarningKindsByWarningMode(
       off: [],
       warning: [],
       error: []
-    } as Record<Nsci.WarningMode, Nsci.WarningKind[]>
+    } as Record<Nsci.WarningMode, Nsci.WarningName[]>
   );
 
   // All warnings defined with the "error" mode
@@ -108,7 +108,7 @@ function groupWarningKindsByWarningMode(
 
 function retrieveAllWarningsWithSpecificMode(
   warnings: DependencyWarning[],
-  warningsWithSpecificMode: Record<Nsci.WarningKind, Nsci.WarningMode>
+  warningsWithSpecificMode: Record<Nsci.WarningName, Nsci.WarningMode>
 ): CheckableFunction<DependencyWarningWithMode> {
   const { allWarningsKindsWithErrorMode, allWarningsKindsWithWarningMode } =
     groupWarningKindsByWarningMode(warningsWithSpecificMode);
@@ -190,7 +190,7 @@ export function checkDependenciesWarnings(
       retrieveAllWarningsWithSpecificMode(
         warnings,
         runtimeConfiguration.warnings as Record<
-          Nsci.WarningKind,
+          Nsci.WarningName,
           Nsci.WarningMode
         >
       )

--- a/src/configuration/external/adapt.ts
+++ b/src/configuration/external/adapt.ts
@@ -50,8 +50,8 @@ function isValidWarningMode(
 
 function isValidWarningKind(
   warningKind: string
-): warningKind is Nsci.WarningKind {
-  return Nsci.warningKinds.includes(warningKind as Nsci.WarningKind);
+): warningKind is Nsci.WarningName {
+  return Nsci.warningNames.includes(warningKind as Nsci.WarningName);
 }
 
 function adaptWarnings(warnings: Nsci.Warnings): Nsci.Warnings {

--- a/src/configuration/standard/nsci.ts
+++ b/src/configuration/standard/nsci.ts
@@ -30,10 +30,10 @@ export const warnings = {
   OFF: "off",
   WARNING: "warning"
 } as const;
-export const warningKinds = Object.keys(jsxray.warnings) as Array<WarningKind>;
+export const warningNames = Object.keys(jsxray.warnings) as Array<WarningName>;
 
 export type WarningMode = ValueOf<typeof warnings>;
-export type WarningKind = keyof typeof jsxray.warnings;
+export type WarningName = keyof typeof jsxray.warnings;
 export type Warnings = WarningMode | Record<jsxray.WarningName, WarningMode>;
 
 export const reporterTarget = {
@@ -42,6 +42,7 @@ export const reporterTarget = {
 } as const;
 
 export type ReporterTarget = ValueOf<typeof reporterTarget>;
+
 export type Configuration = {
   rootDir: string;
   strategy: ValueOf<typeof vulnStrategy>;

--- a/src/configuration/standard/nsci.ts
+++ b/src/configuration/standard/nsci.ts
@@ -1,5 +1,5 @@
 // Import Third-party Dependencies
-import type JSXRay from "@nodesecure/js-x-ray";
+import * as jsxray from "@nodesecure/js-x-ray";
 
 // Import Internal Dependencies
 import { ValueOf } from "../../types";
@@ -30,27 +30,11 @@ export const warnings = {
   OFF: "off",
   WARNING: "warning"
 } as const;
+export const warningKinds = Object.keys(jsxray.warnings) as Array<WarningKind>;
 
 export type WarningMode = ValueOf<typeof warnings>;
-
-// These warnings types should probably come from JSXRay but are hosted here for now
-
-export const warningKinds: Readonly<(JSXRay.WarningName | "unsafe-import")[]> =
-  [
-    "parsing-error",
-    "encoded-literal",
-    "unsafe-regex",
-    "unsafe-stmt",
-    "unsafe-assign",
-    "short-identifiers",
-    "suspicious-literal",
-    "obfuscated-code",
-    "unsafe-import"
-  ] as const;
-
-export type WarningKind = JSXRay.WarningName | "unsafe-import";
-
-export type Warnings = WarningMode | Record<WarningKind, WarningMode>;
+export type WarningKind = keyof typeof jsxray.warnings;
+export type Warnings = WarningMode | Record<jsxray.WarningName, WarningMode>;
 
 export const reporterTarget = {
   CONSOLE: "console",
@@ -58,7 +42,6 @@ export const reporterTarget = {
 } as const;
 
 export type ReporterTarget = ValueOf<typeof reporterTarget>;
-
 export type Configuration = {
   rootDir: string;
   strategy: ValueOf<typeof vulnStrategy>;


### PR DESCRIPTION
fixes #16 

The first iteration on the subject mainly focuses on types now provided directly from `@nodesecure/js-x-ray`.
We could still do improvements about few of these warnings types in the codebase but right now many are coming from `@nodesecure/scanner` (not directly from js-x-ray) [which is not up-to-date with latest type definitions](https://github.com/NodeSecure/scanner/issues/60), so I suggest to do that later.